### PR TITLE
fix: exploit md5 hash to solve the limit of label on gitalk

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -165,7 +165,7 @@ gitalk:
   repo:
   owner:
   admin:
-
+  md5: false
 # https://giscus.app/zh-CN
 giscus:
   enable: false

--- a/layout/_partial/after-footer.ejs
+++ b/layout/_partial/after-footer.ejs
@@ -85,14 +85,18 @@
 
 <% if (theme.gitalk.enable && theme.gitalk.clientID && theme.gitalk.clientSecret) { %>
   <%- js({src: vendorCdn(theme.vendor.js.gitalk)[0], 'data-pjax': true}) %>
+  <% if (theme.gitalk.md5) { %>
+    <script src="https://fastly.jsdelivr.net/npm/blueimp-md5@2.19.0/js/md5.min.js"></script>
+  <% } %>
   <script data-pjax>
+    const id = <%= theme.gitalk.md5 ? 'md5(location.pathname)' : 'location.pathname' %>
     const gitalk = new Gitalk({
       clientID: '<%= theme.gitalk.clientID %>',
       clientSecret: '<%= theme.gitalk.clientSecret %>',
       repo: '<%= theme.gitalk.repo %>',
       owner: '<%= theme.gitalk.owner %>',
       admin: <%- JSON.stringify(theme.gitalk.admin) %>,
-      id: location.pathname, // Ensure uniqueness and length less than 50
+      id: id, // Ensure uniqueness and length less than 50
       distractionFreeMode: false // Facebook-like distraction free mode
     })
     gitalk.render('comments')


### PR DESCRIPTION
gitalk评论系统基于Github issues。gitalk会将文章名称转码添加到issues的label里，但是因为issues限制label长度仅为50，中文博客标题转码后非常容易超出长度，从而出现Error: Validation Failed错误。具体参照[报错出现 Error: Validation Failed.](https://github.com/gitalk/gitalk/issues/102)。
文章名经URL编码后转MD5，可以最大程度避免这个问题。在`_config.yml`添加gitalk的md5布尔值判断来启用该功能。