### PR TITLE
fix: Copyright year duplication (e.g. 2025-2025)

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -8,7 +8,13 @@
     <% } %>
     <div>
       <span class="icon-copyright"></span>
-      <%= theme.footer.since %>-<%= date(new Date(), 'YYYY') %>
+      <% const currentYear = new Date().getFullYear(); %>
+      <% const sinceYear = parseInt(theme.footer.since, 10); %>
+      <% if (sinceYear === currentYear) { %>
+        <%= sinceYear %>
+      <% } else { %>
+        <%= sinceYear %>-<%= currentYear %>
+      <% } %>
       <span class="footer-info-sep <%- theme.footer.icon?.rotate ? 'rotate' : '' %>"></span>
       <%= config.author || config.title %>
     </div>


### PR DESCRIPTION
Was 
![image](https://github.com/user-attachments/assets/5b0e4764-37ff-480f-8a89-83c2c6c48809)

Now
![image](https://github.com/user-attachments/assets/28bd05d1-5ccd-46e2-9b15-365e01624e6f)
