### PR TITLE
Hpjack666

### DIFF
--- a/source/js/heat_map.js
+++ b/source/js/heat_map.js
@@ -252,7 +252,8 @@ function completeContributionData(userData) {
 
   // 获取起始日期和当前日期
   const startDate = new Date(userData[0].date);
-  const currentDate = new Date();
+  const currentYear = new Date().getFullYear();
+  const currentDate = new Date(currentYear, 11, 31);
 
   // 初始化结果数组
   const allData = {};

--- a/source/js/heat_map.js
+++ b/source/js/heat_map.js
@@ -189,18 +189,41 @@ function createCalendar(element, contributionData) {
 
     const monthFragment = document.createDocumentFragment();
     const tilesFragment = document.createDocumentFragment();
+	
+	// 获取当前年份用于比较
+    const currentYear = new Date().getFullYear();
+    const isCurrentYear = year === currentYear;
+	
+	// 初始化月份计数器（仅当前年份需要）
+    const monthSundayCount = isCurrentYear ? {} : null;
 
     const [tiles, totalStatistical] = data.reduce(
       ([tiles, stats], c, i) => {
         const date = new Date(c.date);
         const month = date.getMonth();
+		
+		// 判断是否是周日
+		const isSunday = date.getDay() === 0;
+		
+		// 当前年份：记录每月周日次数
+        if (isCurrentYear && isSunday) {
+            monthSundayCount[month] = (monthSundayCount[month] || 0) + 1;
+        }
+
+		let shouldShowMonth = false;
+	  
+	    if (!isCurrentYear) {    // 非当前年份：月份首次出现时显示
+			shouldShowMonth = month !== latestMonth;
+		} else {     // 当前年份：每月第二次周日时显示
+			shouldShowMonth = isSunday && month !== latestMonth && monthSundayCount[month] === 2;
+		}
 
         // 统计逻辑
         stats.count += c.count;
         stats.post += c.post;
 
         // 处理月份标签
-        if (date.getDay() === 0 && month !== latestMonth) {
+        if (shouldShowMonth) {
           const gridColumn = 2 + Math.floor((i + startRow) / 7);
           latestMonth = month;
           const monthLabel = document.createElement("span");
@@ -252,8 +275,7 @@ function completeContributionData(userData) {
 
   // 获取起始日期和当前日期
   const startDate = new Date(userData[0].date);
-  const currentYear = new Date().getFullYear();
-  const currentDate = new Date(currentYear, 11, 31);
+  const currentDate = new Date();
 
   // 初始化结果数组
   const allData = {};


### PR DESCRIPTION
日期热力图的Aug标签和Sep标签重合了
<img width="894" height="174" alt="image" src="https://github.com/user-attachments/assets/9c59d462-c424-4f8c-85a8-3ef152ef9d56" />
原始的逻辑是，年份在每月第一次周日时显示标签，显然有点不够
我实现的逻辑是，非当前年份在月份首次出现时显示标签，当前年份在每月第二次周日时显示标签
修改完后的效果如下，当年月份的消除了标签重合，非当年月份的从第一次出现该月份开始显示标签
<img width="878" height="174" alt="image" src="https://github.com/user-attachments/assets/9592939a-3e95-4207-ad54-6d4835a5f004" />
<img width="869" height="164" alt="image" src="https://github.com/user-attachments/assets/7c8d3967-8a8f-4db6-bcb6-7c09c5538a4d" />
